### PR TITLE
Fix POST/PUT with empty body falling through to GET

### DIFF
--- a/src/curl/curl_main.c
+++ b/src/curl/curl_main.c
@@ -617,6 +617,12 @@ execute_request (CurlSession_T session, TcurlOptions *opts)
   if (method == HTTP_METHOD_DELETE)
     return Curl_delete (session, opts->url);
 
+  if (method == HTTP_METHOD_POST)
+    return Curl_post (session, opts->url, NULL, NULL, 0);
+
+  if (method == HTTP_METHOD_PUT)
+    return Curl_put (session, opts->url, NULL, NULL, 0);
+
   return Curl_get (session, opts->url);
 }
 


### PR DESCRIPTION
Fixes #1

  When opts->data is NULL, execute_request() incorrectly fell through to Curl_get() for POST and PUT methods.

  **Changes:**
  - Added explicit checks for HTTP_METHOD_POST and HTTP_METHOD_PUT in execute_request()

  **Testing:**
  - Verified POST/PUT with empty body now returns 200 from httpbin.org instead of 405